### PR TITLE
feat: deliver Idea1 governance milestone artifacts (#6 #7 #8 #9)

### DIFF
--- a/.github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml
+++ b/.github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml
@@ -1,0 +1,80 @@
+name: Norm Rule Feedback
+description: Report false positives, false negatives, and rule improvement proposals.
+labels: [governance, triage]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to improve norm governance quality with reproducible evidence.
+
+  - type: dropdown
+    attributes:
+      label: Feedback Type
+      options:
+        - False Positive
+        - False Negative
+        - Conflict
+        - Improvement Proposal
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Rule ID
+      placeholder: e.g. L1-SEC-NO-SHELL-UNSAFE
+    validations:
+      required: true
+
+  - type: input
+    attributes:
+      label: Rule Version
+      placeholder: e.g. 1.0.0
+    validations:
+      required: true
+
+  - type: dropdown
+    attributes:
+      label: Impact Level
+      options:
+        - critical
+        - high
+        - medium
+        - low
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Expected Behavior
+      description: What should have happened according to rule intent?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Actual Behavior
+      description: What happened in runtime/CI?
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Evidence
+      description: File paths, lines, report artifacts, links.
+      placeholder: path/to/file.rs:42, report URL, screenshot URL
+    validations:
+      required: true
+
+  - type: textarea
+    attributes:
+      label: Proposed Change
+      description: Matcher/action/schema changes and rollout suggestion.
+
+  - type: checkboxes
+    attributes:
+      label: Checklist
+      options:
+        - label: I linked all relevant issues/PRs.
+          required: true
+        - label: I included enough evidence to reproduce the behavior.
+          required: true

--- a/.github/workflows/exomind-norm-governance-warn.yml
+++ b/.github/workflows/exomind-norm-governance-warn.yml
@@ -1,0 +1,47 @@
+name: exomind-norm-governance-warn
+
+on:
+  pull_request:
+    paths:
+      - "docs/exomind-*.md"
+      - "docs/exomind-rule-catalog-template.json"
+      - "scripts/exomind_norm_governance_warn.py"
+      - ".github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml"
+      - ".github/workflows/exomind-norm-governance-warn.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/exomind-*.md"
+      - "docs/exomind-rule-catalog-template.json"
+      - "scripts/exomind_norm_governance_warn.py"
+      - ".github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml"
+      - ".github/workflows/exomind-norm-governance-warn.yml"
+
+jobs:
+  norm-governance-warn:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Generate warn-only governance report
+        run: |
+          mkdir -p artifacts
+          python3 scripts/exomind_norm_governance_warn.py \
+            --catalog docs/exomind-rule-catalog-template.json \
+            --markdown-out artifacts/norm-governance-report.md \
+            --json-out artifacts/norm-governance-report.json
+
+      - name: Upload governance report artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: norm-governance-report
+          path: artifacts/norm-governance-report.*

--- a/docs/exomind-norm-feedback-template.md
+++ b/docs/exomind-norm-feedback-template.md
@@ -1,0 +1,42 @@
+# Exomind Norm Feedback Template (M4)
+
+Use this template to record false positives, false negatives, and rule iteration proposals.
+
+## 1. Context
+- `report_date`:
+- `repo`:
+- `branch_or_pr`:
+- `reporter`:
+- `rule_id`:
+- `rule_version`:
+
+## 2. Feedback Type
+- `feedback_type`: `false_positive | false_negative | conflict | improvement`
+- `impact_level`: `critical | high | medium | low`
+
+## 3. Observation
+- `expected_behavior`:
+- `actual_behavior`:
+- `evidence`: file path(s), line(s), or report artifact links.
+
+## 4. Root Cause (Initial)
+- `suspected_cause`: matcher gap, missing context, precedence issue, or bad action mapping.
+- `related_rules`: list of rule ids if conflict exists.
+
+## 5. Proposed Change
+- `proposal_summary`:
+- `schema_or_matcher_change`:
+- `action_change`:
+- `rollout_plan`: 10% -> 50% -> 100%.
+
+## 6. Decision & Release
+- `owner_review_result`: accepted/rejected/deferred.
+- `decision_reason`:
+- `target_release_version`:
+- `post_release_validation_window`:
+
+## 7. Closure Checklist
+- [ ] Added/updated tests or fixtures.
+- [ ] Updated catalog version.
+- [ ] Linked to tracking issue or PR.
+- [ ] Added regression sample to knowledge base.

--- a/docs/exomind-norm-governance-plan.md
+++ b/docs/exomind-norm-governance-plan.md
@@ -113,3 +113,18 @@
 - 本地实时校验引擎（MVP）。
 - CI 审查 Gate 与报告模板。
 - 规则演进提案模板与审批流程。
+
+## 13. 里程碑交付快照（2026-03-06）
+对应 issue：`#6` `#7` `#8` `#9`
+
+- `#7` Rule Catalog 模板与样例
+  - `docs/exomind-rule-catalog-template.json`
+  - `docs/exomind-rule-catalog-spec.md`
+- `#9` 冲突裁决接口草案
+  - `docs/exomind-rule-conflict-resolution-interface.md`
+- `#6` CI Warn 模式入口与基础报告
+  - `scripts/exomind_norm_governance_warn.py`
+  - `.github/workflows/exomind-norm-governance-warn.yml`
+- `#8` 误报/漏报反馈闭环模板
+  - `docs/exomind-norm-feedback-template.md`
+  - `.github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml`

--- a/docs/exomind-rule-catalog-spec.md
+++ b/docs/exomind-rule-catalog-spec.md
@@ -1,0 +1,40 @@
+# Exomind Rule Catalog Spec (M1)
+
+## Purpose
+Define a machine-readable rule catalog schema that can be consumed by Codex CLI policy runtime and CI warn checks.
+
+## Minimal Schema
+Top-level fields:
+- `catalog_version`: semantic version for schema payload.
+- `updated_at`: catalog update date in `YYYY-MM-DD`.
+- `owner`: catalog owner group.
+- `rules`: array of rule objects.
+
+Rule object required fields:
+- `rule_id`: stable unique identifier.
+- `title`: concise human-readable rule name.
+- `rule_level`: one of `L1`, `L2`, `L3`.
+- `severity`: one of `critical`, `high`, `medium`, `low`.
+- `scope`: repository path scope pattern.
+- `owner`: rule owner team or role.
+- `version`: rule semantic version.
+- `matcher`: object with `type`, `value`, `language`.
+- `action`: one of `warn`, `block`, `autofix`, `refactor_hint`.
+- `evidence`: object with `required_fields` array and optional `note`.
+
+## Priority Mapping
+- `L1`: architecture/security constitutional rules. Default `block`.
+- `L2`: domain/testing rules. Default `warn` or `block`.
+- `L3`: style/convention rules. Default `warn` or `autofix`.
+
+Conflict precedence:
+1. `rule_level` (`L1 > L2 > L3`)
+2. `severity` (`critical > high > medium > low`)
+3. `version` (latest wins) and owner arbitration fallback
+
+## Example Catalog
+- Template file: `docs/exomind-rule-catalog-template.json`
+- Included examples:
+  - `L1-SEC-NO-SHELL-UNSAFE`
+  - `L2-TEST-CHANGED-CODE-HAS-TEST`
+  - `L3-STYLE-IMPORT-ORDER`

--- a/docs/exomind-rule-catalog-template.json
+++ b/docs/exomind-rule-catalog-template.json
@@ -1,0 +1,76 @@
+{
+  "catalog_version": "0.1.0",
+  "updated_at": "2026-03-06",
+  "owner": "exomind-team",
+  "rules": [
+    {
+      "rule_id": "L1-SEC-NO-SHELL-UNSAFE",
+      "title": "Disallow shell command construction with untrusted interpolation",
+      "rule_level": "L1",
+      "severity": "critical",
+      "scope": "codex-rs/**",
+      "owner": "security-architecture",
+      "version": "1.0.0",
+      "matcher": {
+        "type": "semantic_pattern",
+        "value": "shell_command(arg contains untrusted_user_input)",
+        "language": "rust"
+      },
+      "action": "block",
+      "evidence": {
+        "required_fields": [
+          "file_path",
+          "line",
+          "snippet"
+        ],
+        "note": "Capture exact interpolated command fragment."
+      }
+    },
+    {
+      "rule_id": "L2-TEST-CHANGED-CODE-HAS-TEST",
+      "title": "Changed runtime logic should include or update tests",
+      "rule_level": "L2",
+      "severity": "high",
+      "scope": "codex-rs/**",
+      "owner": "runtime-quality",
+      "version": "1.0.0",
+      "matcher": {
+        "type": "diff_heuristic",
+        "value": "runtime_code_changed && no_test_file_changed",
+        "language": "generic"
+      },
+      "action": "warn",
+      "evidence": {
+        "required_fields": [
+          "pr_number",
+          "changed_files",
+          "missing_tests_hint"
+        ],
+        "note": "Suggest candidate test modules based on changed paths."
+      }
+    },
+    {
+      "rule_id": "L3-STYLE-IMPORT-ORDER",
+      "title": "Keep imports grouped and sorted by project convention",
+      "rule_level": "L3",
+      "severity": "low",
+      "scope": "codex-rs/**",
+      "owner": "dev-experience",
+      "version": "1.0.0",
+      "matcher": {
+        "type": "ast_pattern",
+        "value": "imports_not_sorted_by_group_then_alpha",
+        "language": "rust"
+      },
+      "action": "autofix",
+      "evidence": {
+        "required_fields": [
+          "file_path",
+          "line_range",
+          "autofix_patch"
+        ],
+        "note": "Autofix patch should be attached to the report."
+      }
+    }
+  ]
+}

--- a/docs/exomind-rule-conflict-resolution-interface.md
+++ b/docs/exomind-rule-conflict-resolution-interface.md
@@ -1,0 +1,69 @@
+# Exomind Rule Conflict Resolution Interface (M2)
+
+## Goal
+Define an implementation-ready interface for resolving rule conflicts before actions are applied in local runtime and CI checks.
+
+## Integration Points
+- After generation, before showing assistant output.
+- Before write-to-disk operation.
+- Before command execution.
+- During CI batch evaluation for pull requests.
+
+## Data Contracts
+`RuleMatch`
+- `rule_id: string`
+- `rule_level: "L1" | "L2" | "L3"`
+- `severity: "critical" | "high" | "medium" | "low"`
+- `action: "warn" | "block" | "autofix" | "refactor_hint"`
+- `scope: string`
+- `version: string`
+- `owner: string`
+- `evidence: object`
+
+`ResolutionDecision`
+- `winner_rule_id: string`
+- `suppressed_rule_ids: string[]`
+- `final_action: "warn" | "block" | "autofix" | "refactor_hint"`
+- `reason: string`
+
+## Interface Draft
+```text
+resolve_conflicts(matches: RuleMatch[]) -> ResolutionDecision[]
+```
+
+Behavior:
+1. Group matches by overlap key (`scope + matcher signature + evidence anchor`).
+2. Inside each group, sort by precedence:
+   - `rule_level`: L1 > L2 > L3
+   - `severity`: critical > high > medium > low
+   - `version`: latest semantic version
+3. Emit one decision per overlap group, preserve suppressed rule ids for audit.
+4. If top two candidates are still indistinguishable, mark `reason=owner_arbitration_required`.
+
+## Pseudocode
+```text
+for group in group_by_overlap(matches):
+  ranked = sort(group, by=[level_desc, severity_desc, version_desc])
+  winner = ranked[0]
+  losers = ranked[1:]
+  decisions.append({
+    winner_rule_id: winner.rule_id,
+    suppressed_rule_ids: [x.rule_id for x in losers],
+    final_action: winner.action,
+    reason: build_reason(winner, losers),
+  })
+```
+
+## Example Conflict Cases
+1. Same matcher, L1 `block` vs L3 `autofix`:
+- winner: L1 `block`.
+
+2. Same level L2, severity `high` warn vs severity `medium` block:
+- winner: severity `high` match.
+- final action follows winning rule payload.
+
+3. Same level and severity, different versions:
+- winner: latest version.
+
+4. Fully tied:
+- winner chosen by deterministic order, decision reason marks owner arbitration required.

--- a/docs/exomind-task-list.md
+++ b/docs/exomind-task-list.md
@@ -50,10 +50,20 @@
 - [-] 想法一的长期治理任务持续拆解并通过 issue/PR 追踪至完成
 
 ## G. 下一阶段（未完成）
-- [ ] 设计并提交 Rule Catalog 模板（含 L1/L2/L3 示例，Issue `#7`）
-- [ ] 定义规则冲突裁决接口草案（映射到 Codex CLI 执行点，Issue `#9`）
-- [ ] 建立 CI “warn 模式”入口并输出基础报告格式（Issue `#6`）
-- [ ] 形成误报/漏报反馈闭环模板（issue/PR 模板或文档，Issue `#8`）
+- [x] 设计并提交 Rule Catalog 模板（含 L1/L2/L3 示例，Issue `#7`）
+- [x] 定义规则冲突裁决接口草案（映射到 Codex CLI 执行点，Issue `#9`）
+- [x] 建立 CI “warn 模式”入口并输出基础报告格式（Issue `#6`）
+- [x] 形成误报/漏报反馈闭环模板（issue/PR 模板或文档，Issue `#8`）
 
 ## H. 当前活跃 PR
-- [-] 跟踪同步 PR：`#5`（任务清单/issue 状态同步）
+- [x] 跟踪同步 PR：`#5`（任务清单/issue 状态同步，已合并）
+- [-] 里程碑落地 PR：待创建（#6/#7/#8/#9 交付物）
+
+## I. Idea1 子任务实施（本轮）
+- [x] `#7` 规则目录模板与样例：`docs/exomind-rule-catalog-template.json`
+- [x] `#7` 规则目录规范文档：`docs/exomind-rule-catalog-spec.md`
+- [x] `#9` 冲突裁决接口草案：`docs/exomind-rule-conflict-resolution-interface.md`
+- [x] `#6` warn 模式脚本：`scripts/exomind_norm_governance_warn.py`
+- [x] `#6` warn 模式 workflow：`.github/workflows/exomind-norm-governance-warn.yml`
+- [x] `#8` 反馈流程模板文档：`docs/exomind-norm-feedback-template.md`
+- [x] `#8` 反馈 issue 模板：`.github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml`

--- a/scripts/exomind_norm_governance_warn.py
+++ b/scripts/exomind_norm_governance_warn.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+"""Generate warn-only norm governance reports from a rule catalog template."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+VALID_LEVELS = {"L1", "L2", "L3"}
+VALID_SEVERITIES = {"critical", "high", "medium", "low"}
+VALID_ACTIONS = {"warn", "block", "autofix", "refactor_hint"}
+REQUIRED_RULE_FIELDS = {
+    "rule_id",
+    "title",
+    "rule_level",
+    "severity",
+    "scope",
+    "owner",
+    "version",
+    "matcher",
+    "action",
+    "evidence",
+}
+REQUIRED_MATCHER_FIELDS = {"type", "value", "language"}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--catalog", required=True, help="Path to rule catalog JSON file.")
+    parser.add_argument(
+        "--markdown-out",
+        required=True,
+        help="Output markdown report path.",
+    )
+    parser.add_argument(
+        "--json-out",
+        required=True,
+        help="Output machine-readable report path.",
+    )
+    return parser.parse_args()
+
+
+def load_catalog(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError("catalog must be a JSON object")
+    return data
+
+
+def add_warning(
+    warnings: list[dict[str, str]],
+    code: str,
+    message: str,
+    rule_id: str | None = None,
+) -> None:
+    warning = {"code": code, "message": message}
+    if rule_id:
+        warning["rule_id"] = rule_id
+    warnings.append(warning)
+
+
+def validate_rules(rules: list[dict[str, Any]]) -> list[dict[str, str]]:
+    warnings: list[dict[str, str]] = []
+    seen_rule_ids: set[str] = set()
+
+    for i, rule in enumerate(rules):
+        if not isinstance(rule, dict):
+            add_warning(
+                warnings,
+                "RULE_TYPE_INVALID",
+                f"rules[{i}] is not an object",
+            )
+            continue
+
+        missing_fields = sorted(REQUIRED_RULE_FIELDS - set(rule.keys()))
+        rule_id = str(rule.get("rule_id", f"rules[{i}]"))
+        if missing_fields:
+            add_warning(
+                warnings,
+                "RULE_FIELD_MISSING",
+                f"missing fields: {', '.join(missing_fields)}",
+                rule_id,
+            )
+
+        if rule_id in seen_rule_ids:
+            add_warning(
+                warnings,
+                "RULE_ID_DUPLICATED",
+                "rule_id is duplicated in catalog",
+                rule_id,
+            )
+        seen_rule_ids.add(rule_id)
+
+        level = rule.get("rule_level")
+        if level not in VALID_LEVELS:
+            add_warning(
+                warnings,
+                "RULE_LEVEL_INVALID",
+                f"invalid rule_level: {level}",
+                rule_id,
+            )
+
+        severity = rule.get("severity")
+        if severity not in VALID_SEVERITIES:
+            add_warning(
+                warnings,
+                "RULE_SEVERITY_INVALID",
+                f"invalid severity: {severity}",
+                rule_id,
+            )
+
+        action = rule.get("action")
+        if action not in VALID_ACTIONS:
+            add_warning(
+                warnings,
+                "RULE_ACTION_INVALID",
+                f"invalid action: {action}",
+                rule_id,
+            )
+
+        matcher = rule.get("matcher")
+        if not isinstance(matcher, dict):
+            add_warning(
+                warnings,
+                "MATCHER_INVALID",
+                "matcher must be an object",
+                rule_id,
+            )
+        else:
+            matcher_missing = sorted(REQUIRED_MATCHER_FIELDS - set(matcher.keys()))
+            if matcher_missing:
+                add_warning(
+                    warnings,
+                    "MATCHER_FIELD_MISSING",
+                    f"matcher missing fields: {', '.join(matcher_missing)}",
+                    rule_id,
+                )
+
+    return warnings
+
+
+def detect_conflicts(rules: list[dict[str, Any]]) -> list[dict[str, str]]:
+    conflicts: list[dict[str, str]] = []
+    # Heuristic: same scope + same matcher(type,value,language) but different action.
+    for i in range(len(rules)):
+        left = rules[i]
+        if not isinstance(left, dict):
+            continue
+        left_matcher = left.get("matcher")
+        if not isinstance(left_matcher, dict):
+            continue
+        for j in range(i + 1, len(rules)):
+            right = rules[j]
+            if not isinstance(right, dict):
+                continue
+            right_matcher = right.get("matcher")
+            if not isinstance(right_matcher, dict):
+                continue
+
+            same_scope = left.get("scope") == right.get("scope")
+            same_matcher = (
+                left_matcher.get("type") == right_matcher.get("type")
+                and left_matcher.get("value") == right_matcher.get("value")
+                and left_matcher.get("language") == right_matcher.get("language")
+            )
+            action_differs = left.get("action") != right.get("action")
+
+            if same_scope and same_matcher and action_differs:
+                conflicts.append(
+                    {
+                        "left_rule_id": str(left.get("rule_id", f"rules[{i}]")),
+                        "right_rule_id": str(right.get("rule_id", f"rules[{j}]")),
+                        "reason": "same_scope_and_matcher_but_action_differs",
+                    }
+                )
+    return conflicts
+
+
+def to_markdown(report: dict[str, Any]) -> str:
+    lines: list[str] = []
+    lines.append("# Norm Governance Warn Report")
+    lines.append("")
+    lines.append(f"- Generated at: `{report['generated_at']}`")
+    lines.append(f"- Catalog path: `{report['catalog_path']}`")
+    lines.append(f"- Rules total: `{report['rules_total']}`")
+    lines.append(f"- Warnings total: `{report['warnings_total']}`")
+    lines.append(f"- Potential conflicts: `{report['conflicts_total']}`")
+    lines.append("")
+
+    lines.append("## Warnings")
+    if report["warnings"]:
+        for warning in report["warnings"]:
+            prefix = warning.get("rule_id", "catalog")
+            lines.append(
+                f"- `{warning['code']}` `{prefix}`: {warning['message']}"
+            )
+    else:
+        lines.append("- None")
+    lines.append("")
+
+    lines.append("## Potential Conflicts")
+    if report["conflicts"]:
+        for conflict in report["conflicts"]:
+            lines.append(
+                "- "
+                f"`{conflict['left_rule_id']}` vs `{conflict['right_rule_id']}`: "
+                f"{conflict['reason']}"
+            )
+    else:
+        lines.append("- None")
+    lines.append("")
+    lines.append("## Mode")
+    lines.append("- warn-only: this report does not fail CI.")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+
+    catalog_path = Path(args.catalog)
+    markdown_out = Path(args.markdown_out)
+    json_out = Path(args.json_out)
+
+    catalog = load_catalog(catalog_path)
+    rules = catalog.get("rules", [])
+    if not isinstance(rules, list):
+        raise ValueError("catalog.rules must be an array")
+
+    typed_rules = [r for r in rules if isinstance(r, dict)]
+    warnings = validate_rules(typed_rules)
+    conflicts = detect_conflicts(typed_rules)
+
+    report = {
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "catalog_path": str(catalog_path).replace("\\", "/"),
+        "rules_total": len(typed_rules),
+        "warnings_total": len(warnings),
+        "conflicts_total": len(conflicts),
+        "warnings": warnings,
+        "conflicts": conflicts,
+        "mode": "warn-only",
+    }
+
+    markdown_out.parent.mkdir(parents=True, exist_ok=True)
+    json_out.parent.mkdir(parents=True, exist_ok=True)
+    markdown_out.write_text(to_markdown(report), encoding="utf-8")
+    json_out.write_text(json.dumps(report, indent=2), encoding="utf-8")
+
+    print(
+        "norm-governance warn report generated:",
+        markdown_out.as_posix(),
+        json_out.as_posix(),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- deliver Idea1 milestone artifacts for #6 #7 #8 #9
- add Rule Catalog template + spec + conflict-resolution interface draft
- add warn-only CI workflow and report generator script
- add norm feedback templates (docs + issue form)
- sync task list and governance plan milestone snapshot

## Deliverables by Issue
- #7 Rule Catalog:
  - `docs/exomind-rule-catalog-template.json`
  - `docs/exomind-rule-catalog-spec.md`
- #9 Conflict interface:
  - `docs/exomind-rule-conflict-resolution-interface.md`
- #6 CI warn mode:
  - `scripts/exomind_norm_governance_warn.py`
  - `.github/workflows/exomind-norm-governance-warn.yml`
- #8 Feedback loop:
  - `docs/exomind-norm-feedback-template.md`
  - `.github/ISSUE_TEMPLATE/7-norm-rule-feedback.yml`

## Validation
- `python scripts/exomind_norm_governance_warn.py --catalog docs/exomind-rule-catalog-template.json --markdown-out .tmp/norm-governance-report.md --json-out .tmp/norm-governance-report.json` ✅
- `cargo check -p codex-tui` ✅ (`codex-rs/`, `CARGO_TARGET_DIR=G:\codex-rs-target`)

## Tracking
- Parent: #1
- Context ledger: #3

Closes #6
Closes #7
Closes #8
Closes #9