### PR TITLE
docs: add Exomind fork status block to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,20 @@ If you want Codex in your code editor (VS Code, Cursor, Windsurf), <a href="http
 </br>If you want the desktop app experience, run <code>codex app</code> or visit <a href="https://chatgpt.com/codex?app-landing-page=true">the Codex App page</a>.
 </br>If you are looking for the <em>cloud-based agent</em> from OpenAI, <strong>Codex Web</strong>, go to <a href="https://chatgpt.com/codex">chatgpt.com/codex</a>.</p>
 
+> [!NOTE]
+> **Exomind fork status**
+> This fork tracks `openai/codex` and carries a small set of workflow-level changes on top of upstream.
+> - README section updated on `2026-03-07`
+> - Latest `upstream/main` observed at update time: `9a4787c24`
+> - Current fork/upstream merge-base: `b6d43ec8`
+> - Fork-specific additions currently include:
+>   - a shared pending-input queue for repeating queue and repeating steer messages, with distinct preview colors
+>   - `Shift+Tab` cycling collaboration mode when the composer is empty, and enqueuing a repeating queue message otherwise
+>   - `Alt+↑` recalling the most recently enqueued queue or steer draft by enqueue order
+>   - Termux compatibility work and a stable Android build path
+>   - fork-specific CI compatibility adjustments plus governance/task-tracking experiments
+> - When this block changes, update the `upstream/main` hash in the same PR so the fork baseline stays auditable
+
 ---
 
 ## Quickstart


### PR DESCRIPTION
## Summary
- add an `Exomind fork status` note near the top of `README.md`
- list the current fork-only workflow changes users should know about
- record the latest `upstream/main` hash observed during the README update so future refreshes have an audit anchor

## Upstream anchors captured in README
- `upstream/main`: `9a4787c24`
- fork/upstream merge-base: `b6d43ec8`
- fork main at authoring time: `be65ee8d9`

## Validation
- docs-only change; no build or test run required

Closes #25