### PR TITLE
Add Termux cargo resource wrappers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,13 +20,19 @@ In the codex-rs folder where the rust code lives:
 - After dependency changes, run `just bazel-lock-check` from the repo root so lockfile drift is caught
   locally before CI.
 - Do not create small helper methods that are referenced only once.
+- On Termux/Android, use `scripts/termux/cargo-safe.sh ...` and `scripts/termux/just-safe.sh ...`
+  instead of invoking `cargo` or `just` directly for repo tasks. These wrappers inject
+  conservative resource settings only on Termux and act as passthrough elsewhere.
 
-Run `just fmt` (in `codex-rs` directory) automatically after you have finished making Rust code changes; do not ask for approval to run it. Additionally, run the tests:
+Run `just fmt` (in `codex-rs` directory) automatically after you have finished making Rust code changes; do not ask for approval to run it. On Termux/Android, run `scripts/termux/just-safe.sh fmt` instead of invoking `just` directly. Additionally, run the tests:
 
 1. Run the test for the specific project that was changed. For example, if changes were made in `codex-rs/tui`, run `cargo test -p codex-tui`.
+   On Termux/Android, use `scripts/termux/cargo-safe.sh test -p codex-tui`.
 2. Once those pass, if any changes were made in common, core, or protocol, run the complete test suite with `cargo test` (or `just test` if `cargo-nextest` is installed). Avoid `--all-features` for routine local runs because it expands the build matrix and can significantly increase `target/` disk usage; use it only when you specifically need full feature coverage. project-specific or individual tests can be run without asking the user, but do ask the user before running the complete test suite.
+   On Termux/Android, use `scripts/termux/cargo-safe.sh test` or `scripts/termux/just-safe.sh test`.
 
 Before finalizing a large change to `codex-rs`, run `just fix -p <project>` (in `codex-rs` directory) to fix any linter issues in the code. Prefer scoping with `-p` to avoid slow workspace‑wide Clippy builds; only run `just fix` without `-p` if you changed shared crates. Do not re-run tests after running `fix` or `fmt`.
+On Termux/Android, use `scripts/termux/just-safe.sh fix -p <project>`.
 
 ## TUI style conventions
 

--- a/scripts/termux/README.md
+++ b/scripts/termux/README.md
@@ -2,15 +2,50 @@
 
 Scripts in this folder are for validating and developing Termux support in the `exomind-codex` local project branch.
 
-## `build-safe.sh`
+## `cargo-env.sh`
 
-Builds `codex-cli` and `codex-exec` for Android/Termux with low-memory defaults:
+Shared Termux resource layer for Cargo-based commands.
 
+- detects Termux/Android via `TERMUX_VERSION` or the Termux `PREFIX`
 - computes a conservative `CARGO_BUILD_JOBS` from current `MemAvailable`
-- forces `release` overrides to reduce linker memory spikes:
+- exports low-risk debug/profile overrides:
   - `CARGO_PROFILE_RELEASE_LTO=off`
   - `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16`
   - `CARGO_PROFILE_RELEASE_DEBUG=0`
+  - `CARGO_PROFILE_DEV_DEBUG=0`
+  - `CARGO_PROFILE_TEST_DEBUG=0`
+- warns when `/data` usage is high
+- is a no-op passthrough outside Termux
+
+This script is meant to be sourced by other scripts in this folder.
+
+## `cargo-safe.sh`
+
+Runs `cargo` through the shared Termux resource layer.
+
+Usage:
+
+```sh
+scripts/termux/cargo-safe.sh test -p codex-tui
+scripts/termux/cargo-safe.sh check -p codex-cli --target aarch64-linux-android
+```
+
+## `just-safe.sh`
+
+Runs `just` through the shared Termux resource layer.
+
+Usage:
+
+```sh
+scripts/termux/just-safe.sh fmt
+scripts/termux/just-safe.sh fix -p codex-tui
+```
+
+## `build-safe.sh`
+
+Builds `codex-cli` and `codex-exec` for Android/Termux using the shared resource layer.
+
+This script prints the computed Termux settings, then delegates to `cargo-safe.sh`.
 
 Usage:
 
@@ -22,8 +57,22 @@ scripts/termux/build-safe.sh
 
 Runs Android ARM64 preflight checks and cargo compile checks for key crates.
 
+This script keeps the existing target validation flow, then delegates actual `cargo check`
+invocations to `cargo-safe.sh`.
+
+## `test-resource-layer.sh`
+
+Script-level regression checks for the resource wrapper layer.
+
+It validates:
+
+- non-Termux passthrough behavior
+- Termux-only environment injection
+- wrapper exit-code passthrough
+- `build-safe.sh` and `check-android-target.sh` integration with the shared layer
+
 Usage:
 
 ```sh
-scripts/termux/check-android-target.sh
+scripts/termux/test-resource-layer.sh
 ```

--- a/scripts/termux/build-safe.sh
+++ b/scripts/termux/build-safe.sh
@@ -2,6 +2,7 @@
 set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 TARGET="aarch64-linux-android"
 
 need_cmd() {
@@ -14,38 +15,17 @@ need_cmd() {
 need_cmd cargo
 need_cmd rustc
 
-cores=$(nproc 2>/dev/null || echo 1)
-mem_kb=$(awk '/MemAvailable:/ { print $2 }' /proc/meminfo 2>/dev/null || echo 0)
-
-# Conservative job tuning for mobile memory pressure.
-if [ "${mem_kb:-0}" -lt 3000000 ]; then
-  jobs=1
-elif [ "${mem_kb:-0}" -lt 5000000 ]; then
-  jobs=2
-else
-  jobs=$((cores / 2))
-  [ "$jobs" -lt 2 ] && jobs=2
-  [ "$jobs" -gt 4 ] && jobs=4
-fi
-
-data_use_pct=$(df -P /data 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }')
-if [ -n "${data_use_pct:-}" ] && [ "${data_use_pct:-0}" -ge 92 ]; then
-  echo "[termux-build-safe] warning: /data usage is ${data_use_pct}% (low free space may cause instability)." >&2
-fi
+. "$SCRIPT_DIR/cargo-env.sh"
 
 echo "[termux-build-safe] target: $TARGET"
-echo "[termux-build-safe] cores: $cores"
-echo "[termux-build-safe] MemAvailable: ${mem_kb} kB"
-echo "[termux-build-safe] CARGO_BUILD_JOBS=$jobs"
-echo "[termux-build-safe] release overrides: LTO=off, codegen-units=16, debug=0"
+echo "[termux-build-safe] cores: ${TERMUX_CARGO_ENV_CORES:-unknown}"
+echo "[termux-build-safe] MemAvailable: ${TERMUX_CARGO_ENV_MEM_KB:-unknown} kB"
+echo "[termux-build-safe] CARGO_BUILD_JOBS=${CARGO_BUILD_JOBS:-unset}"
+echo "[termux-build-safe] release overrides: LTO=${CARGO_PROFILE_RELEASE_LTO:-unset}, codegen-units=${CARGO_PROFILE_RELEASE_CODEGEN_UNITS:-unset}, debug=${CARGO_PROFILE_RELEASE_DEBUG:-unset}"
+echo "[termux-build-safe] dev/test debug overrides: dev=${CARGO_PROFILE_DEV_DEBUG:-unset}, test=${CARGO_PROFILE_TEST_DEBUG:-unset}"
 
 cd "$ROOT_DIR/codex-rs"
-
-CARGO_BUILD_JOBS="$jobs" \
-CARGO_PROFILE_RELEASE_LTO=off \
-CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16 \
-CARGO_PROFILE_RELEASE_DEBUG=0 \
-cargo build --release -p codex-cli -p codex-exec --target "$TARGET"
+sh "$SCRIPT_DIR/cargo-safe.sh" build --release -p codex-cli -p codex-exec --target "$TARGET"
 
 echo "[termux-build-safe] done"
 echo "[termux-build-safe] binaries:"

--- a/scripts/termux/cargo-env.sh
+++ b/scripts/termux/cargo-env.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "${TERMUX_CARGO_ENV_LOADED:-0}" = "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+TERMUX_CARGO_ENV_LOADED=1
+TERMUX_CARGO_ENV_ACTIVE=0
+TERMUX_CARGO_ENV_CORES=""
+TERMUX_CARGO_ENV_MEM_KB=""
+TERMUX_CARGO_ENV_DATA_USE_PCT=""
+TERMUX_CARGO_ENV_JOBS=""
+export TERMUX_CARGO_ENV_LOADED
+
+is_termux=0
+if [ -n "${TERMUX_VERSION:-}" ]; then
+  is_termux=1
+else
+  case "${PREFIX:-}" in
+    /data/data/com.termux/* | /data/user/*/com.termux/*)
+      is_termux=1
+      ;;
+  esac
+fi
+
+if [ "$is_termux" -ne 1 ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+TERMUX_CARGO_ENV_ACTIVE=1
+TERMUX_CARGO_ENV_CORES=$(nproc 2>/dev/null || echo 1)
+TERMUX_CARGO_ENV_MEM_KB=$(awk '/MemAvailable:/ { print $2 }' /proc/meminfo 2>/dev/null || echo 0)
+
+if [ "${TERMUX_CARGO_ENV_MEM_KB:-0}" -lt 3000000 ]; then
+  TERMUX_CARGO_ENV_JOBS=1
+elif [ "${TERMUX_CARGO_ENV_MEM_KB:-0}" -lt 5000000 ]; then
+  TERMUX_CARGO_ENV_JOBS=2
+else
+  TERMUX_CARGO_ENV_JOBS=$((TERMUX_CARGO_ENV_CORES / 2))
+  if [ "$TERMUX_CARGO_ENV_JOBS" -lt 2 ]; then
+    TERMUX_CARGO_ENV_JOBS=2
+  fi
+  if [ "$TERMUX_CARGO_ENV_JOBS" -gt 4 ]; then
+    TERMUX_CARGO_ENV_JOBS=4
+  fi
+fi
+
+TERMUX_CARGO_ENV_DATA_USE_PCT=$(df -P /data 2>/dev/null | awk 'NR==2 { gsub(/%/, "", $5); print $5 }')
+
+CARGO_BUILD_JOBS=$TERMUX_CARGO_ENV_JOBS
+CARGO_PROFILE_RELEASE_LTO=off
+CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16
+CARGO_PROFILE_RELEASE_DEBUG=0
+CARGO_PROFILE_DEV_DEBUG=0
+CARGO_PROFILE_TEST_DEBUG=0
+
+export TERMUX_CARGO_ENV_ACTIVE
+export TERMUX_CARGO_ENV_CORES
+export TERMUX_CARGO_ENV_MEM_KB
+export TERMUX_CARGO_ENV_DATA_USE_PCT
+export TERMUX_CARGO_ENV_JOBS
+export CARGO_BUILD_JOBS
+export CARGO_PROFILE_RELEASE_LTO
+export CARGO_PROFILE_RELEASE_CODEGEN_UNITS
+export CARGO_PROFILE_RELEASE_DEBUG
+export CARGO_PROFILE_DEV_DEBUG
+export CARGO_PROFILE_TEST_DEBUG
+
+if [ -n "${TERMUX_CARGO_ENV_DATA_USE_PCT:-}" ] && [ "${TERMUX_CARGO_ENV_DATA_USE_PCT:-0}" -ge 92 ] && [ "${TERMUX_CARGO_ENV_WARNED:-0}" != "1" ]; then
+  echo "[termux-cargo-env] warning: /data usage is ${TERMUX_CARGO_ENV_DATA_USE_PCT}% (low free space may cause instability)." >&2
+  TERMUX_CARGO_ENV_WARNED=1
+  export TERMUX_CARGO_ENV_WARNED
+fi

--- a/scripts/termux/cargo-safe.sh
+++ b/scripts/termux/cargo-safe.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/cargo-env.sh"
+
+exec cargo "$@"

--- a/scripts/termux/check-android-target.sh
+++ b/scripts/termux/check-android-target.sh
@@ -2,6 +2,7 @@
 set -eu
 
 ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
 TARGET="aarch64-linux-android"
 
 need_cmd() {
@@ -37,7 +38,7 @@ fi
 
 cd "$ROOT_DIR/codex-rs"
 echo "[termux-check] cargo check -p codex-cli --target $TARGET"
-cargo check -p codex-cli --target "$TARGET"
+sh "$SCRIPT_DIR/cargo-safe.sh" check -p codex-cli --target "$TARGET"
 echo "[termux-check] cargo check -p codex-tui --target $TARGET"
-cargo check -p codex-tui --target "$TARGET"
+sh "$SCRIPT_DIR/cargo-safe.sh" check -p codex-tui --target "$TARGET"
 echo "[termux-check] done"

--- a/scripts/termux/just-safe.sh
+++ b/scripts/termux/just-safe.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env sh
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+. "$SCRIPT_DIR/cargo-env.sh"
+
+exec just "$@"

--- a/scripts/termux/test-resource-layer.sh
+++ b/scripts/termux/test-resource-layer.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env sh
+set -eu
+
+ROOT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")/../.." && pwd)
+SCRIPTS_DIR="$ROOT_DIR/scripts/termux"
+SYSTEM_PATH=${PATH:-/usr/bin:/bin}
+TARGET="aarch64-linux-android"
+
+assert_eq() {
+  actual=$1
+  expected=$2
+  label=$3
+  if [ "$actual" != "$expected" ]; then
+    echo "assert_eq failed for $label: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+assert_empty() {
+  value=$1
+  label=$2
+  if [ -n "$value" ]; then
+    echo "assert_empty failed for $label: got '$value'" >&2
+    exit 1
+  fi
+}
+
+assert_contains() {
+  haystack=$1
+  needle=$2
+  label=$3
+  case $haystack in
+    *"$needle"*) ;;
+    *)
+      echo "assert_contains failed for $label: missing '$needle'" >&2
+      exit 1
+      ;;
+  esac
+}
+
+parse_var() {
+  payload=$1
+  key=$2
+  printf '%s\n' "$payload" | sed -n "s/^${key}=//p" | head -n 1
+}
+
+expected_jobs() {
+  cores=$(nproc 2>/dev/null || echo 1)
+  mem_kb=$(awk '/MemAvailable:/ { print $2 }' /proc/meminfo 2>/dev/null || echo 0)
+
+  if [ "${mem_kb:-0}" -lt 3000000 ]; then
+    echo 1
+    return
+  fi
+
+  if [ "${mem_kb:-0}" -lt 5000000 ]; then
+    echo 2
+    return
+  fi
+
+  jobs=$((cores / 2))
+  if [ "$jobs" -lt 2 ]; then
+    jobs=2
+  fi
+  if [ "$jobs" -gt 4 ]; then
+    jobs=4
+  fi
+  echo "$jobs"
+}
+
+TMP_DIR=$(mktemp -d "$ROOT_DIR/.tmp-termux-resource-layer.XXXXXX")
+trap 'rm -rf "$TMP_DIR"' EXIT INT TERM
+FAKE_BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$FAKE_BIN_DIR"
+
+cat >"$FAKE_BIN_DIR/cargo" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'tool=cargo\n'
+printf 'argv=%s\n' "$*"
+printf 'CARGO_BUILD_JOBS=%s\n' "${CARGO_BUILD_JOBS-}"
+printf 'CARGO_PROFILE_RELEASE_LTO=%s\n' "${CARGO_PROFILE_RELEASE_LTO-}"
+printf 'CARGO_PROFILE_RELEASE_CODEGEN_UNITS=%s\n' "${CARGO_PROFILE_RELEASE_CODEGEN_UNITS-}"
+printf 'CARGO_PROFILE_RELEASE_DEBUG=%s\n' "${CARGO_PROFILE_RELEASE_DEBUG-}"
+printf 'CARGO_PROFILE_DEV_DEBUG=%s\n' "${CARGO_PROFILE_DEV_DEBUG-}"
+printf 'CARGO_PROFILE_TEST_DEBUG=%s\n' "${CARGO_PROFILE_TEST_DEBUG-}"
+exit "${FAKE_EXIT_CODE:-0}"
+EOF
+
+cat >"$FAKE_BIN_DIR/just" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+printf 'tool=just\n'
+printf 'argv=%s\n' "$*"
+printf 'CARGO_BUILD_JOBS=%s\n' "${CARGO_BUILD_JOBS-}"
+printf 'CARGO_PROFILE_RELEASE_LTO=%s\n' "${CARGO_PROFILE_RELEASE_LTO-}"
+printf 'CARGO_PROFILE_RELEASE_CODEGEN_UNITS=%s\n' "${CARGO_PROFILE_RELEASE_CODEGEN_UNITS-}"
+printf 'CARGO_PROFILE_RELEASE_DEBUG=%s\n' "${CARGO_PROFILE_RELEASE_DEBUG-}"
+printf 'CARGO_PROFILE_DEV_DEBUG=%s\n' "${CARGO_PROFILE_DEV_DEBUG-}"
+printf 'CARGO_PROFILE_TEST_DEBUG=%s\n' "${CARGO_PROFILE_TEST_DEBUG-}"
+exit "${FAKE_EXIT_CODE:-0}"
+EOF
+
+cat >"$FAKE_BIN_DIR/rustc" <<EOF
+#!/usr/bin/env sh
+set -eu
+if [ "\${1:-}" = "-vV" ]; then
+  printf 'host: $TARGET\n'
+  exit 0
+fi
+printf 'fake rustc\n'
+EOF
+
+chmod +x "$FAKE_BIN_DIR/cargo" "$FAKE_BIN_DIR/just" "$FAKE_BIN_DIR/rustc"
+
+TERMUX_PREFIX="/data/data/com.termux/files/usr"
+NON_TERMUX_PREFIX="/usr/local"
+EXPECTED_JOBS=$(expected_jobs)
+
+non_termux_cargo=$(
+  env -i \
+    HOME="$TMP_DIR/home" \
+    PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+    PREFIX="$NON_TERMUX_PREFIX" \
+    sh "$SCRIPTS_DIR/cargo-safe.sh" check -p codex-tui
+)
+assert_eq "$(parse_var "$non_termux_cargo" tool)" "cargo" "non-termux cargo tool"
+assert_eq "$(parse_var "$non_termux_cargo" argv)" "check -p codex-tui" "non-termux cargo argv"
+assert_empty "$(parse_var "$non_termux_cargo" CARGO_BUILD_JOBS)" "non-termux cargo jobs"
+assert_empty "$(parse_var "$non_termux_cargo" CARGO_PROFILE_DEV_DEBUG)" "non-termux cargo dev debug"
+
+termux_cargo=$(
+  env -i \
+    HOME="$TMP_DIR/home" \
+    PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+    PREFIX="$TERMUX_PREFIX" \
+    TERMUX_VERSION="0.118.1" \
+    sh "$SCRIPTS_DIR/cargo-safe.sh" check -p codex-tui
+)
+assert_eq "$(parse_var "$termux_cargo" tool)" "cargo" "termux cargo tool"
+assert_eq "$(parse_var "$termux_cargo" argv)" "check -p codex-tui" "termux cargo argv"
+assert_eq "$(parse_var "$termux_cargo" CARGO_BUILD_JOBS)" "$EXPECTED_JOBS" "termux cargo jobs"
+assert_eq "$(parse_var "$termux_cargo" CARGO_PROFILE_RELEASE_LTO)" "off" "termux cargo release lto"
+assert_eq "$(parse_var "$termux_cargo" CARGO_PROFILE_RELEASE_CODEGEN_UNITS)" "16" "termux cargo release codegen units"
+assert_eq "$(parse_var "$termux_cargo" CARGO_PROFILE_RELEASE_DEBUG)" "0" "termux cargo release debug"
+assert_eq "$(parse_var "$termux_cargo" CARGO_PROFILE_DEV_DEBUG)" "0" "termux cargo dev debug"
+assert_eq "$(parse_var "$termux_cargo" CARGO_PROFILE_TEST_DEBUG)" "0" "termux cargo test debug"
+
+termux_just=$(
+  env -i \
+    HOME="$TMP_DIR/home" \
+    PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+    PREFIX="$TERMUX_PREFIX" \
+    TERMUX_VERSION="0.118.1" \
+    sh "$SCRIPTS_DIR/just-safe.sh" -l
+)
+assert_eq "$(parse_var "$termux_just" tool)" "just" "termux just tool"
+assert_eq "$(parse_var "$termux_just" argv)" "-l" "termux just argv"
+assert_eq "$(parse_var "$termux_just" CARGO_BUILD_JOBS)" "$EXPECTED_JOBS" "termux just jobs"
+
+set +e
+env -i \
+  FAKE_EXIT_CODE=23 \
+  HOME="$TMP_DIR/home" \
+  PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+  PREFIX="$TERMUX_PREFIX" \
+  TERMUX_VERSION="0.118.1" \
+  sh "$SCRIPTS_DIR/cargo-safe.sh" metadata --format-version 1 >/dev/null
+status=$?
+set -e
+assert_eq "$status" "23" "cargo-safe exit code"
+
+build_output=$(
+  env -i \
+    HOME="$TMP_DIR/home" \
+    PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+    PREFIX="$TERMUX_PREFIX" \
+    TERMUX_VERSION="0.118.1" \
+    sh "$SCRIPTS_DIR/build-safe.sh" 2>&1
+)
+assert_contains "$build_output" "argv=build --release -p codex-cli -p codex-exec --target $TARGET" "build-safe cargo args"
+assert_contains "$build_output" "CARGO_PROFILE_RELEASE_LTO=off" "build-safe release lto"
+assert_contains "$build_output" "CARGO_PROFILE_DEV_DEBUG=0" "build-safe dev debug"
+
+check_output=$(
+  env -i \
+    HOME="$TMP_DIR/home" \
+    PATH="$FAKE_BIN_DIR:$SYSTEM_PATH" \
+    PREFIX="$TERMUX_PREFIX" \
+    TERMUX_VERSION="0.118.1" \
+    sh "$SCRIPTS_DIR/check-android-target.sh" 2>&1
+)
+assert_contains "$check_output" "argv=check -p codex-cli --target $TARGET" "check script cli args"
+assert_contains "$check_output" "argv=check -p codex-tui --target $TARGET" "check script tui args"
+assert_contains "$check_output" "CARGO_PROFILE_TEST_DEBUG=0" "check script test debug"
+
+printf 'termux resource layer script checks passed\n'


### PR DESCRIPTION
## Summary
- add a shared Termux cargo resource layer via `scripts/termux/cargo-env.sh`
- add `scripts/termux/cargo-safe.sh` and `scripts/termux/just-safe.sh` as standard Termux wrappers
- refactor existing Termux helper scripts and document the wrapper-based workflow

## What changed
- add Termux-only resource env injection for Cargo-based commands
- keep non-Termux behavior as passthrough
- update `scripts/termux/build-safe.sh` and `scripts/termux/check-android-target.sh` to reuse the shared layer
- add `scripts/termux/test-resource-layer.sh` for wrapper-level regression checks
- update `AGENTS.md` and `scripts/termux/README.md` to point Termux usage at the safe wrappers

## Resource settings
On Termux, the shared env layer exports:
- `CARGO_BUILD_JOBS`
- `CARGO_PROFILE_RELEASE_LTO=off`
- `CARGO_PROFILE_RELEASE_CODEGEN_UNITS=16`
- `CARGO_PROFILE_RELEASE_DEBUG=0`
- `CARGO_PROFILE_DEV_DEBUG=0`
- `CARGO_PROFILE_TEST_DEBUG=0`

## Verification
- verified `scripts/termux/cargo-env.sh` directly for Termux and non-Termux branches
- did not run `cargo-safe.sh` or `just-safe.sh` through real Rust builds in this pass
- did not run Rust crate builds or tests from this PR branch

## Notes
- this PR only covers the script layer and documentation
- no Codex-side enforcement or hook blocking is included yet
